### PR TITLE
Control the included quota and storage providers via Go build tags

### DIFF
--- a/cmd/internal/provider/cloudspanner.go
+++ b/cmd/internal/provider/cloudspanner.go
@@ -1,0 +1,7 @@
+//go:build cloudspanner || !(crdb || mysql || postgresql)
+
+package provider
+
+import (
+	_ "github.com/google/trillian/storage/cloudspanner"
+)

--- a/cmd/internal/provider/crdb.go
+++ b/cmd/internal/provider/crdb.go
@@ -1,0 +1,9 @@
+//go:build crdb || !(cloudspanner || mysql || postgresql)
+
+package provider
+
+import (
+	_ "github.com/google/trillian/storage/crdb"
+
+	_ "github.com/google/trillian/quota/crdbqm"
+)

--- a/cmd/internal/provider/mysql.go
+++ b/cmd/internal/provider/mysql.go
@@ -1,0 +1,9 @@
+//go:build mysql || !(cloudspanner || crdb || postgresql)
+
+package provider
+
+import (
+	_ "github.com/google/trillian/storage/mysql"
+
+	_ "github.com/google/trillian/quota/mysqlqm"
+)

--- a/cmd/internal/provider/postgresql.go
+++ b/cmd/internal/provider/postgresql.go
@@ -1,0 +1,9 @@
+//go:build postgresql || !(cloudspanner || crdb || mysql)
+
+package provider
+
+import (
+	_ "github.com/google/trillian/storage/postgresql"
+
+	_ "github.com/google/trillian/quota/postgresqlqm"
+)

--- a/cmd/trillian_log_server/main.go
+++ b/cmd/trillian_log_server/main.go
@@ -45,16 +45,8 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 
-	// Register supported storage providers.
-	_ "github.com/google/trillian/storage/cloudspanner"
-	_ "github.com/google/trillian/storage/crdb"
-	_ "github.com/google/trillian/storage/mysql"
-	_ "github.com/google/trillian/storage/postgresql"
-
-	// Load quota providers
-	_ "github.com/google/trillian/quota/crdbqm"
-	_ "github.com/google/trillian/quota/mysqlqm"
-	_ "github.com/google/trillian/quota/postgresqlqm"
+	// Register supported storage and quota providers.
+	_ "github.com/google/trillian/cmd/internal/provider"
 )
 
 var (

--- a/cmd/trillian_log_signer/main.go
+++ b/cmd/trillian_log_signer/main.go
@@ -51,16 +51,8 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
 
-	// Register supported storage providers.
-	_ "github.com/google/trillian/storage/cloudspanner"
-	_ "github.com/google/trillian/storage/crdb"
-	_ "github.com/google/trillian/storage/mysql"
-	_ "github.com/google/trillian/storage/postgresql"
-
-	// Load quota providers
-	_ "github.com/google/trillian/quota/crdbqm"
-	_ "github.com/google/trillian/quota/mysqlqm"
-	_ "github.com/google/trillian/quota/postgresqlqm"
+	// Register supported storage and quota providers.
+	_ "github.com/google/trillian/cmd/internal/provider"
 )
 
 var (


### PR DESCRIPTION
https://github.com/google/trillian/pull/3644#discussion_r1822420304 notes that the log-signer and log-server binaries are huge, due in part to the presence of multiple quota and storage providers.  This PR enables providers to be included selectively via Go build tags.

By default and for backwards compatibility, all providers are included:
```bash
> go build && ls -sh trillian_log_server
62M trillian_log_server*
```

Specify one build tag to include just one provider:
```bash
> go build -tags=cloudspanner && ls -sh trillian_log_server
54M trillian_log_server*
> go build -tags=crdb && ls -sh trillian_log_server
37M trillian_log_server*
> go build -tags=mysql && ls -sh trillian_log_server
34M trillian_log_server*
> go build -tags=postgresql && ls -sh trillian_log_server
40M trillian_log_server*
```

Specify multiple, comma-separated build tags to include multiple providers.  e.g.,:
```bash
> go build -tags=mysql,postgresql && ls -sh trillian_log_server
40M trillian_log_server*
> go build -tags=cloudspanner,crdb,mysql,postgresql && ls -sh trillian_log_server
62M trillian_log_server*
```